### PR TITLE
perf: Reuse a goroutine instead of spawning a new one

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,8 +33,8 @@ func main() {
 				return
 			}
 
-			go io.Copy(other, c)
 			go io.Copy(c, other)
+			io.Copy(other, c)
 		}(con)
 	}
 }


### PR DESCRIPTION
This is a very minor optimization and have 2 effects :
- Instead of spawning a new goroutine and killing the old one just reuse the one about to die for copy.
- Avoid scheding for the inbound copy (allowing to copy the first inbound buffer a tiny bit earlier).